### PR TITLE
Fix parent relationships of sub-sub-maven-modules and make JPMS module_info work with Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <java.version>15</java.version>
-        <spring.boot.version>2.5.2</spring.boot.version>
+        <spring.boot.version>2.6.2</spring.boot.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/todo-list-jpms-application/todo-list-jpms-rest/pom.xml
+++ b/todo-list-jpms-application/todo-list-jpms-rest/pom.xml
@@ -7,7 +7,7 @@
 
     <parent>
         <groupId>net.mguenther.todo</groupId>
-        <artifactId>todo-list-jpms</artifactId>
+        <artifactId>todo-list-jpms-application</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 

--- a/todo-list-jpms-infrastructure/todo-list-jpms-persistence-jpa/pom.xml
+++ b/todo-list-jpms-infrastructure/todo-list-jpms-persistence-jpa/pom.xml
@@ -7,7 +7,7 @@
 
     <parent>
         <groupId>net.mguenther.todo</groupId>
-        <artifactId>todo-list-jpms</artifactId>
+        <artifactId>todo-list-jpms-infrastructure</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 

--- a/todo-list-jpms-infrastructure/todo-list-jpms-persistence-jpa/src/main/java/module-info.java
+++ b/todo-list-jpms-infrastructure/todo-list-jpms-persistence-jpa/src/main/java/module-info.java
@@ -6,8 +6,10 @@ module todo.persistence.jpa {
     requires java.sql;
     requires java.xml.bind;
 
+    requires spring.beans;
     requires spring.boot.autoconfigure;
     requires spring.context;
+    requires spring.data.commons;
     requires spring.data.jpa;
     requires spring.jdbc;
     requires spring.tx;
@@ -18,8 +20,10 @@ module todo.persistence.jpa {
 
     requires com.fasterxml.classmate;
 
+    requires org.hibernate.orm.core;
+
     exports net.mguenther.todo.persistence.jpa;
 
-    opens net.mguenther.todo.persistence.jpa.impl to spring.core, spring.beans, org.hibernate.orm.core;
+    opens net.mguenther.todo.persistence.jpa.impl to spring.core, spring.beans, spring.context, org.hibernate.orm.core;
     opens net.mguenther.todo.persistence.jpa.config to spring.core, spring.beans, spring.context;
 }

--- a/todo-list-jpms-infrastructure/todo-list-jpms-rest-app/pom.xml
+++ b/todo-list-jpms-infrastructure/todo-list-jpms-rest-app/pom.xml
@@ -7,7 +7,7 @@
 
     <parent>
         <groupId>net.mguenther.todo</groupId>
-        <artifactId>todo-list-jpms</artifactId>
+        <artifactId>todo-list-jpms-infrastructure</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 

--- a/todo-list-jpms-infrastructure/todo-list-jpms-rest-app/src/main/java/module-info.java
+++ b/todo-list-jpms-infrastructure/todo-list-jpms-rest-app/src/main/java/module-info.java
@@ -7,6 +7,9 @@ module todo.rest.app {
     requires spring.boot;
     requires spring.boot.autoconfigure;
 
+    requires spring.core;
+    requires spring.context;
+
     // otherwise the embedded Tomcat server will not be started and the
     // application terminates itself after creating the persistence unit
     requires org.apache.tomcat.embed.core;


### PR DESCRIPTION
Heya

in order to make the multi-module Maven project build against an .m2-repository that is fresh, i.e. does not have your parent pom yet, the sub-sub-modules need to reference the sub-module parent (which then refer to the project's root parent pom), else the build breaks.

Additionally I modified the module_info.java files to work with Java 17.

Cheers. Christian.